### PR TITLE
Use new version format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "license": "GPL-2.0+",
     "conflict": {
         "drupal/drupal": "<8.0.0-beta2,<8.0.4",
-        "drupal/dynamic_entity_reference": "<8.1.0-beta2",
-        "drupal/echo": "<8.1.7",
-        "drupal/nodejs": "<8.1.0",
-        "drupal/search_api": "<8.1.0-alpha14",
-        "drupal/xmlsitemap": "<8.1.0-alpha2"
+        "drupal/dynamic_entity_reference": "<1.0.0-beta2",
+        "drupal/echo": "<1.7.0",
+        "drupal/nodejs": "<1.0.0",
+        "drupal/search_api": "<1.0.0-alpha14",
+        "drupal/xmlsitemap": "<1.0.0-alpha2"
     }
 }


### PR DESCRIPTION
Most composer installations to this point have used https://packagist.drupal-composer.org, which used a version format like this: `"drupal/search_api": "8.1.0-alpha14"`

However, packagist.drupal-composer.org is [now deprecated](https://www.drupal.org/node/2718229) in favor of packages.drupal.org. packages.drupal.org recommends a new version format: `"drupal/search_api": "1.0.0-alpha14"`

This is problematic for projects using drupal-security-advisories (DSA) that want to switch to packages.drupal.org, because DSA will detect these new version strings as security vulnerabilities.
