### PR TITLE
Add webflo/drupal-core-require-dev, mirroring drupal/core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "drupal/tmgmt": "<1.7",
         "drupal/video": "<1.4",
         "drupal/workbench_moderation": "<1.4",
-        "drupal/xmlsitemap": "<1.0-alpha2"
+        "drupal/xmlsitemap": "<1.0-alpha2",
+        "webflo/drupal-core-require-dev": "<8.0.0-beta2,<8.0.4,<8.1.3,<8.1.7,<8.1.10,<8.2.3,<8.2.7,<8.2.8,<8.3.1,<8.3.4,<8.3.7,<8.3.9,<8.4.6,<8.4.7,<8.4.8,<8.5.1,<8.5.2,<8.5.3,<8.5.6,<8.5.8,<8.5.9,<8.5.11,<8.6.2,<8.6.6,<8.6.10"
     }
 }


### PR DESCRIPTION
When Drupal Core is installed  via [Acquia's BLT](https://github.com/acquia/blt), it depends on `webflo/drupal-core-require-dev` rather than `drupal/core`.

Subsequently, commands such as `drush pm:security` don't find `drupal/core` in `composer.lock`. 

It does find `webflo/drupal-core-require-dev`, but that isn't found in https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/8.x/composer.json.

Therefore `drush pm:security` incorrectly reports:

> There are no outstanding security updates for Drupal projects.

---

This PR adds `webflo/drupal-core-require-dev`, mirroring the version numbers of `drupal/core`.

The same versioning is used:

> ``webflo/drupal-core-require-dev`` provides the ``require-dev`` dependencies of ``drupal/core`` as a standalone package. It follows the same release cycle and versioning scheme as Drupal core. You should use the same version constraint for it as you use for Drupal core.

https://github.com/webflo/drupal-core-require-dev