### PR TITLE
Fix constraints generated for D7 core

### DIFF
--- a/build/src/VersionParser.php
+++ b/build/src/VersionParser.php
@@ -26,6 +26,9 @@ class VersionParser {
 
   public static function handleCore($version) {
     list($major, $minor) = explode('.', $version);
+    if ($major == '7') {
+      return ">=$major,<$version";
+    }
     return ">=$major.$minor,<$version";
   }
 


### PR DESCRIPTION
Only include minor version for D8+, so that D7 contraints are in the format `>7,<=7.67`

Related to drupal-composer/drupal-security-advisories#11