### PR TITLE
Handle D9 core SAs and handle semver contrib releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package ensures that your application doesn't have installed dependencies w
 
 ## Installation
 
-### Drupal 8/9 ([composer.json](https://github.com/drupal-composer/drupal-security-advisories/blob/8.x/composer.json))
+### Drupal 8+ ([composer.json](https://github.com/drupal-composer/drupal-security-advisories/blob/8.x/composer.json))
 
 ```sh
 ~$ composer require drupal-composer/drupal-security-advisories:8.x-dev

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package ensures that your application doesn't have installed dependencies w
 
 ## Installation
 
-### Drupal 8 ([composer.json](https://github.com/drupal-composer/drupal-security-advisories/blob/8.x/composer.json))
+### Drupal 8/9 ([composer.json](https://github.com/drupal-composer/drupal-security-advisories/blob/8.x/composer.json))
 
 ```sh
 ~$ composer require drupal-composer/drupal-security-advisories:8.x-dev

--- a/build/src/VersionParser.php
+++ b/build/src/VersionParser.php
@@ -35,8 +35,21 @@ class VersionParser {
     // $result->taxonomy_vocabulary_6 is usually a term like 8.x (https://www.drupal.org/taxonomy/term/7234).
     // Its absence indicates a semver release (or a core release).
     list($core, $version) = empty($result->taxonomy_vocabulary_6) ? [NULL, $version] : explode('-', $version, 2);
-    list($major, $minor) = explode('.', $version, 2);
-    return ">=$major.$minor,<$version";
+    $version_components = explode('.', $version);
+    if (count($version_components) === 2) {
+      // Only major.minor, either Drupal core 7, or contrib that had an API compatibility prefix.
+      list($major) = $version_components;
+      return ">=$major,<$version";
+    }
+    elseif (count($version_components) === 3) {
+      // Semver, either Drupal core 8 or later, or contrib using semver.
+      list($major, $minor) = $version_components;
+      return ">=$major.$minor,<$version";
+    }
+    else {
+      // Should not happen. An exception will be thrown by the caller.
+      return NULL;
+    }
   }
 
   public static function isValid($version) {

--- a/build/src/VersionParser.php
+++ b/build/src/VersionParser.php
@@ -35,8 +35,8 @@ class VersionParser {
     // $result->taxonomy_vocabulary_6 is usually a term like 8.x (https://www.drupal.org/taxonomy/term/7234).
     // Its absence indicates a semver release (or a core release).
     list($core, $version) = empty($result->taxonomy_vocabulary_6) ? [NULL, $version] : explode('-', $version, 2);
-    list($major) = explode('.', $version);
-    return ">=$major,<$version";
+    list($major, $minor) = explode('.', $version, 2);
+    return ">=$major.$minor,<$version";
   }
 
   public static function isValid($version) {

--- a/build/src/VersionParser.php
+++ b/build/src/VersionParser.php
@@ -4,14 +4,14 @@ namespace DrupalComposer\DrupalSecurityAdvisories;
 
 class VersionParser {
 
-  public static function generateRangeConstraint($version, $isCore) {
+  public static function generateRangeConstraint($version, $isCore, $result) {
     if (!static::isValid($version)) {
       return FALSE;
     }
-    return $isCore ? static::handleCore($version) : static::handleContrib($version);
+    return $isCore ? static::handleCore($version) : static::handleContrib($version, $result);
   }
 
-  public static function generateExplicitConstraint($version, $isCore) {
+  public static function generateExplicitConstraint($version, $isCore, $result) {
     if (!static::isValid($version)) {
       return FALSE;
     }
@@ -19,7 +19,9 @@ class VersionParser {
       return $version;
     }
     else {
-      list($core, $version) = explode('-', $version, 2);
+      // $result->taxonomy_vocabulary_6 is usually a term like 8.x (https://www.drupal.org/taxonomy/term/7234).
+      // Its absence indicates a semver release (or a core release).
+      list($core, $version) = empty($result->taxonomy_vocabulary_6) ? [NULL, $version] : explode('-', $version, 2);
     }
     return $version;
   }
@@ -29,8 +31,10 @@ class VersionParser {
     return ">=$major.$minor,<$version";
   }
 
-  public static function handleContrib($version) {
-    list($core, $version) = explode('-', $version, 2);
+  public static function handleContrib($version, $result) {
+    // $result->taxonomy_vocabulary_6 is usually a term like 8.x (https://www.drupal.org/taxonomy/term/7234).
+    // Its absence indicates a semver release (or a core release).
+    list($core, $version) = empty($result->taxonomy_vocabulary_6) ? [NULL, $version] : explode('-', $version, 2);
     list($major) = explode('.', $version);
     return ">=$major,<$version";
   }


### PR DESCRIPTION
This is a PR for build-v2 branch. I think thats right, but please confirm.

I mistakenly published the output of this PR to https://github.com/drupal-composer/drupal-security-advisories/commit/011d54565a1c3dea3854198e7d8be1f224795d05#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780. You can see the D9 core conflict at the end of the `drupal/core` row. My mistake will presumably get overwritten during next Circle run.

I'm working with drumm to publish an SA against a semver release so we can verify that this PR works as intended. There are no real SAs yet against a semver release.